### PR TITLE
Flashmem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,14 +24,13 @@ add_executable(${PROJECT_NAME}
   access_point/host.h
   flashmem/flashmem.c
   flashmem/flashmem.h
-  json/json.c
-  json/json.h
   )
 pico_add_extra_outputs(${PROJECT_NAME})
 target_link_libraries(${PROJECT_NAME}
   pico_cyw43_arch_lwip_threadsafe_background
   pico_stdlib
   pico_lwip_mqtt
+  hardware_flash
   hardware_i2c
   tinyusb_device
   tinyusb_board

--- a/flashmem/flashmem.c
+++ b/flashmem/flashmem.c
@@ -1,0 +1,52 @@
+#include "pico/stdlib.h"
+#include "stdlib.h"
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include "hardware/flash.h"
+
+// Defined in memmap_custom.ld
+extern uint32_t ADDR_PERSISTENT[];
+#define ADDR_PERSISTENT_BASE (ADDR_PERSISTENT)
+
+// Can only write flash in pages of 256 bytes
+#define PAGE_SIZE 256
+// flash sector alignment size
+#define NVS_SIZE 4096
+
+// key1=val1,key2=val2,(etc..)\0
+
+int upsert_key(char* key, char* val, char* buf) {
+  //TODO
+  // if key not present, just append
+  // else splice new value
+  // return 1 if value exceeds 4096
+  //
+  return 0;
+}
+
+int write(char* key, char* val) {
+  uint8_t *buf = malloc(NVS_SIZE);
+
+  memcpy(buf, ADDR_PERSISTENT, NVS_SIZE);
+
+  if (upsert_key(key, val, (char*)buf)) {
+
+  }
+
+  unsigned int mem_size = strlen((char*)buf);
+  int write_size = (mem_size / 256) + (256 - (mem_size % 256));
+
+  //START Critical Section
+  flash_range_erase((uint32_t)ADDR_PERSISTENT_BASE - XIP_BASE, NVS_SIZE);
+  flash_range_program((uint32_t)ADDR_PERSISTENT_BASE - XIP_BASE, buf, write_size);
+  //END Critical Section
+
+  free(buf);
+  return 0;
+}
+
+int read(char* key, char* out_val) {
+
+}
+

--- a/flashmem/flashmem.c
+++ b/flashmem/flashmem.c
@@ -14,14 +14,51 @@ extern uint32_t ADDR_PERSISTENT[];
 // flash sector alignment size
 #define NVS_SIZE 4096
 
+enum _flashmem_err 
+{
+  ERR_OK = 0,
+  ERR_FLASHMEM_SIZE = 1,
+  ERR_INVALID_KEY = 2,
+};
+typedef enum _flashmem_err flashmem_err_t;
+
 // key1=val1,key2=val2,(etc..)\0
 
-int upsert_key(char* key, char* val, char* buf) {
-  //TODO
+// Returns new length
+int esc_chars(char* val) {
+
+}
+
+flashmem_err_t upsert_key(char* key, char* val, char* buf) {
+  if (strrchr(key, '\\') != NULL || strrchr(key, ',') != NULL || strrchr(key, '=') != NULL) {
+    return ERR_INVALID_KEY;
+  }
+
+  // TODO escape all invalid chars in val
+  if (strlen(key) + strlen(val) + strlen(buf) > NVS_SIZE - 1) {
+    return ERR_FLASHMEM_SIZE;
+  }
+
+  int keylen = strlen(key);
+  char *key_search = malloc(keylen + 2);
+  strcpy(key_search, key);
+  key_search[keylen + 1] = '=';
+  key_search[keylen + 2] = '\0';
+
   // if key not present, just append
+  if (strstr(buf, key_search) == NULL) {
+    char *end = strrchr(buf, '\0');
+    strcpy(end, key_search);
+    end = strrchr(buf, '\0');
+    strcpy(end, val);
+    // does strcpy add null to the end of dest?
+  }
+  else {
+
+  }
   // else splice new value
-  // return 1 if value exceeds 4096
-  //
+
+  free(key_search);
   return 0;
 }
 

--- a/json/json.h
+++ b/json/json.h
@@ -1,7 +1,0 @@
-#ifndef JSON_H
-#define JSON_H
-
-int write(char *json, char *key, char *val);
-int read(char *json, char *key, char *out_val);
-
-#endif

--- a/memmap_custom.ld
+++ b/memmap_custom.ld
@@ -1,0 +1,265 @@
+/* MODIFIED VERSION OF memmap_default.ld FROM PICO SDK
+ * COPIED FROM THIS ARTICLE:
+ * https://community.element14.com/products/raspberry-pi/b/blog/posts/raspberry-pico-c-sdk-reserve-a-flash-memory-block-for-persistent-storage
+*/
+/* Based on GCC ARM embedded samples.
+   Defines the following symbols for use by code:
+    __exidx_start
+    __exidx_end
+    __etext
+    __data_start__
+    __preinit_array_start
+    __preinit_array_end
+    __init_array_start
+    __init_array_end
+    __fini_array_start
+    __fini_array_end
+    __data_end__
+    __bss_start__
+    __bss_end__
+    __end__
+    end
+    __HeapLimit
+    __StackLimit
+    __StackTop
+    __stack (== StackTop)
+*/
+
+__PERSISTENT_STORAGE_LEN = 4k ;
+
+MEMORY
+{
+    FLASH(rx) : ORIGIN = 0x10000000, LENGTH = 2048k - __PERSISTENT_STORAGE_LEN
+    FLASH_PERSISTENT(rw) : ORIGIN = 0x10000000 + (2048k - __PERSISTENT_STORAGE_LEN) , LENGTH = __PERSISTENT_STORAGE_LEN
+    RAM(rwx) : ORIGIN =  0x20000000, LENGTH = 256k
+    SCRATCH_X(rwx) : ORIGIN = 0x20040000, LENGTH = 4k
+    SCRATCH_Y(rwx) : ORIGIN = 0x20041000, LENGTH = 4k
+}
+
+ENTRY(_entry_point)
+
+SECTIONS
+{
+    /* Second stage bootloader is prepended to the image. It must be 256 bytes big
+       and checksummed. It is usually built by the boot_stage2 target
+       in the Raspberry Pi Pico SDK
+    */
+
+    .flash_begin : {
+        __flash_binary_start = .;
+    } > FLASH
+
+    .boot2 : {
+        __boot2_start__ = .;
+        KEEP (*(.boot2))
+        __boot2_end__ = .;
+    } > FLASH
+
+    ASSERT(__boot2_end__ - __boot2_start__ == 256,
+        "ERROR: Pico second stage bootloader must be 256 bytes in size")
+
+    /* The second stage will always enter the image at the start of .text.
+       The debugger will use the ELF entry point, which is the _entry_point
+       symbol if present, otherwise defaults to start of .text.
+       This can be used to transfer control back to the bootrom on debugger
+       launches only, to perform proper flash setup.
+    */
+
+    .text : {
+        __logical_binary_start = .;
+        KEEP (*(.vectors))
+        KEEP (*(.binary_info_header))
+        __binary_info_header_end = .;
+        KEEP (*(.reset))
+        /* TODO revisit this now memset/memcpy/float in ROM */
+        /* bit of a hack right now to exclude all floating point and time critical (e.g. memset, memcpy) code from
+         * FLASH ... we will include any thing excluded here in .data below by default */
+        *(.init)
+        *(EXCLUDE_FILE(*libgcc.a: *libc.a:*lib_a-mem*.o *libm.a:) .text*)
+        *(.fini)
+        /* Pull all c'tors into .text */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+        /* Followed by destructors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.eh_frame*)
+        . = ALIGN(4);
+    } > FLASH
+
+    .rodata : {
+        *(EXCLUDE_FILE(*libgcc.a: *libc.a:*lib_a-mem*.o *libm.a:) .rodata*)
+        . = ALIGN(4);
+        *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.flashdata*)))
+        . = ALIGN(4);
+    } > FLASH
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > FLASH
+    __exidx_end = .;
+
+    /* Machine inspectable binary information */
+    . = ALIGN(4);
+    __binary_info_start = .;
+    .binary_info :
+    {
+        KEEP(*(.binary_info.keep.*))
+        *(.binary_info.*)
+    } > FLASH
+    __binary_info_end = .;
+    . = ALIGN(4);
+
+    /* End of .text-like segments */
+    __etext = .;
+
+
+    .section_persisitent : {
+        "ADDR_PERSISTENT" = .;  
+    } > FLASH_PERSISTENT
+    
+   .ram_vector_table (COPY): {
+        *(.ram_vector_table)
+    } > RAM
+
+    .data : {
+        __data_start__ = .;
+        *(vtable)
+
+        *(.time_critical*)
+
+        /* remaining .text and .rodata; i.e. stuff we exclude above because we want it in RAM */
+        *(.text*)
+        . = ALIGN(4);
+        *(.rodata*)
+        . = ALIGN(4);
+
+        *(.data*)
+
+        . = ALIGN(4);
+        *(.after_data.*)
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE_HIDDEN (__mutex_array_start = .);
+        KEEP(*(SORT(.mutex_array.*)))
+        KEEP(*(.mutex_array))
+        PROVIDE_HIDDEN (__mutex_array_end = .);
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP(*(SORT(.preinit_array.*)))
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        *(SORT(.fini_array.*))
+        *(.fini_array)
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        *(.jcr)
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+    } > RAM AT> FLASH
+
+    .uninitialized_data (COPY): {
+        . = ALIGN(4);
+        *(.uninitialized_data*)
+    } > RAM
+
+    /* Start and end symbols must be word-aligned */
+    .scratch_x : {
+        __scratch_x_start__ = .;
+        *(.scratch_x.*)
+        . = ALIGN(4);
+        __scratch_x_end__ = .;
+    } > SCRATCH_X AT > FLASH
+    __scratch_x_source__ = LOADADDR(.scratch_x);
+
+    .scratch_y : {
+        __scratch_y_start__ = .;
+        *(.scratch_y.*)
+        . = ALIGN(4);
+        __scratch_y_end__ = .;
+    } > SCRATCH_Y AT > FLASH
+    __scratch_y_source__ = LOADADDR(.scratch_y);
+
+    .bss  : {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.bss*)))
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+    } > RAM
+
+    .heap (COPY):
+    {
+        __end__ = .;
+        end = __end__;
+        *(.heap*)
+        __HeapLimit = .;
+    } > RAM
+
+    /* .stack*_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later
+     *
+     * stack1 section may be empty/missing if platform_launch_core1 is not used */
+
+    /* by default we put core 0 stack at the end of scratch Y, so that if core 1
+     * stack is not used then all of SCRATCH_X is free.
+     */
+    .stack1_dummy (COPY):
+    {
+        *(.stack1*)
+    } > SCRATCH_X
+    .stack_dummy (COPY):
+    {
+        *(.stack*)
+    } > SCRATCH_Y
+
+    .flash_end : {
+        __flash_binary_end = .;
+    } > FLASH
+
+
+    /* stack limit is poorly named, but historically is maximum heap ptr */
+    __StackLimit = ORIGIN(RAM) + LENGTH(RAM);
+    __StackOneTop = ORIGIN(SCRATCH_X) + LENGTH(SCRATCH_X);
+    __StackTop = ORIGIN(SCRATCH_Y) + LENGTH(SCRATCH_Y);
+    __StackOneBottom = __StackOneTop - SIZEOF(.stack1_dummy);
+    __StackBottom = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed")
+
+    ASSERT( __binary_info_header_end - __logical_binary_start <= 256, "Binary info must be in first 256 bytes of the binary")
+    /* todo assert on extra code */
+}
+


### PR DESCRIPTION
This pull request includes changes to the `CMakeLists.txt`, `flashmem/flashmem.c`, `json/json.h`, and `memmap_custom.ld` files to enhance functionality and remove unused code. The most important changes include removing JSON functionality, adding flash memory operations, and modifying the memory map for persistent storage.

Removal of JSON functionality:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL27-R33): Removed `json/json.c` and `json/json.h` from the project.
* [`json/json.h`](diffhunk://#diff-921a4df4278f8dfc5d6c13f955b2a8f3448d821eef7abdde76f2c4faca4baddcL1-L7): Deleted the entire file, removing JSON read and write functions.

Addition of flash memory operations:

* [`flashmem/flashmem.c`](diffhunk://#diff-713ac26638e781d9f942bf962453c973d46b225fcd6babe6c0c379fc7256b411R1-R179): Added new functions to handle flash memory operations, including `upsert_key`, `write`, and `read`. These functions manage key-value pairs in flash memory with error handling for invalid keys and flash memory size limits.

Modification of memory map for persistent storage:

* [`memmap_custom.ld`](diffhunk://#diff-13ca83891a704d350c7265c58d52126868d209fa2ba2a8a076c364e6ce139e75R1-R265): Modified the memory map to reserve a block of flash memory for persistent storage, defining a new section `FLASH_PERSISTENT` and adding symbols for the persistent storage address.